### PR TITLE
통합검색 기능 개발 (Fulltext 검색으로)

### DIFF
--- a/src/main/java/com/example/outsourcing/config/CustomFunctionContributor.java
+++ b/src/main/java/com/example/outsourcing/config/CustomFunctionContributor.java
@@ -1,0 +1,27 @@
+package com.example.outsourcing.config;
+
+import static org.hibernate.type.StandardBasicTypes.DOUBLE;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+
+public class CustomFunctionContributor implements FunctionContributor {
+
+    private static final String FUNCTION1_NAME = "match_1params_against";
+    private static final String FUNCTION1_PATTERN = "MATCH (?1) AGAINST (?2 in boolean mode)";
+
+    private static final String FUNCTION2_NAME = "match_2params_against";
+    private static final String FUNCTION2_PATTERN = "MATCH (?1, ?2) AGAINST (?3 in boolean mode)";
+
+    @Override
+    public void contributeFunctions(final FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry()
+            .registerPattern(FUNCTION1_NAME, FUNCTION1_PATTERN,
+                functionContributions.getTypeConfiguration().getBasicTypeRegistry()
+                    .resolve(DOUBLE));
+        functionContributions.getFunctionRegistry()
+            .registerPattern(FUNCTION2_NAME, FUNCTION2_PATTERN,
+                functionContributions.getTypeConfiguration().getBasicTypeRegistry()
+                    .resolve(DOUBLE));
+    }
+}

--- a/src/main/java/com/example/outsourcing/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/outsourcing/config/GlobalExceptionHandler.java
@@ -73,6 +73,16 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, errorMessage);
     }
 
+    // 500 서버에러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleException(
+        HttpServletRequest request,
+        Exception e
+    ) {
+        log.error("예상하지 못한 예외가 발생했습니다. URI:{}, 내용:{}", request.getRequestURI(), e.getMessage(), e);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "서버가 응답할 수 없습니다.");
+    }
+
     private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status,
         String message) {
         Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/example/outsourcing/config/PersistenceConfig.java
+++ b/src/main/java/com/example/outsourcing/config/PersistenceConfig.java
@@ -1,5 +1,9 @@
 package com.example.outsourcing.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -7,4 +11,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class PersistenceConfig {
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/com/example/outsourcing/domain/common/exception/base/ErrorCode.java
+++ b/src/main/java/com/example/outsourcing/domain/common/exception/base/ErrorCode.java
@@ -8,6 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    //search
+    SEARCH_KEYWORD_SHORT(HttpStatus.BAD_REQUEST, "검색어가 너무 짧습니다. 2글자 이상 검색해주세요."),
+
     //user
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다. 로그인이 필요합니다."),
     WRONG_EMAIL_OR_PASSWORD(HttpStatus.UNAUTHORIZED, "이메일이나 비밀번호를 잘못 입력하였습니다."),

--- a/src/main/java/com/example/outsourcing/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/outsourcing/domain/search/controller/SearchController.java
@@ -1,0 +1,23 @@
+package com.example.outsourcing.domain.search.controller;
+
+import com.example.outsourcing.domain.search.dto.SearchResponseDto;
+import com.example.outsourcing.domain.search.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping("/search")
+    public ResponseEntity<SearchResponseDto> search(@RequestParam String keyword) {
+        SearchResponseDto searchResult = searchService.searchAll(keyword);
+
+        return ResponseEntity.ok(searchResult);
+    }
+}

--- a/src/main/java/com/example/outsourcing/domain/search/dto/SearchMenuResponseDto.java
+++ b/src/main/java/com/example/outsourcing/domain/search/dto/SearchMenuResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.outsourcing.domain.search.dto;
+
+import java.math.BigDecimal;
+
+public record SearchMenuResponseDto(
+    Long id,
+    String shopName,
+    String name,
+    String description,
+    BigDecimal price
+) {
+
+}

--- a/src/main/java/com/example/outsourcing/domain/search/dto/SearchResponseDto.java
+++ b/src/main/java/com/example/outsourcing/domain/search/dto/SearchResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.outsourcing.domain.search.dto;
+
+import java.util.List;
+
+public record SearchResponseDto(
+    List<SearchShopResponseDto> shops,
+    List<SearchMenuResponseDto> menus
+) {
+
+}

--- a/src/main/java/com/example/outsourcing/domain/search/dto/SearchShopResponseDto.java
+++ b/src/main/java/com/example/outsourcing/domain/search/dto/SearchShopResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.outsourcing.domain.search.dto;
+
+public record SearchShopResponseDto(
+    Long id,
+    String owner,
+    String name
+) {
+
+}

--- a/src/main/java/com/example/outsourcing/domain/search/mapper/SearchMapper.java
+++ b/src/main/java/com/example/outsourcing/domain/search/mapper/SearchMapper.java
@@ -1,0 +1,32 @@
+package com.example.outsourcing.domain.search.mapper;
+
+import com.example.outsourcing.domain.search.dto.SearchMenuResponseDto;
+import com.example.outsourcing.domain.search.dto.SearchResponseDto;
+import com.example.outsourcing.domain.search.dto.SearchShopResponseDto;
+import com.example.outsourcing.domain.shop.entity.Menu;
+import com.example.outsourcing.domain.shop.entity.Shop;
+import java.util.List;
+
+public class SearchMapper {
+
+    public static SearchResponseDto toDto(
+        List<Shop> shopList,
+        List<Menu> menuList
+    ) {
+
+        return new SearchResponseDto(
+            shopList.stream().map(shop -> new SearchShopResponseDto(
+                shop.getId(),
+                shop.getUser().getUsername(),
+                shop.getName()
+            )).toList(),
+            menuList.stream().map(menu -> new SearchMenuResponseDto(
+                menu.getId(),
+                menu.getShop().getName(),
+                menu.getName(),
+                menu.getDescription(),
+                menu.getPrice()
+            )).toList()
+        );
+    }
+}

--- a/src/main/java/com/example/outsourcing/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/outsourcing/domain/search/service/SearchService.java
@@ -1,0 +1,28 @@
+package com.example.outsourcing.domain.search.service;
+
+
+import com.example.outsourcing.domain.search.dto.SearchResponseDto;
+import com.example.outsourcing.domain.search.mapper.SearchMapper;
+import com.example.outsourcing.domain.shop.entity.Menu;
+import com.example.outsourcing.domain.shop.entity.Shop;
+import com.example.outsourcing.domain.shop.repository.MenuRepository;
+import com.example.outsourcing.domain.shop.repository.ShopRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final ShopRepository shopRepository;
+    private final MenuRepository menuRepository;
+
+
+    public SearchResponseDto searchAll(String keyword) {
+        List<Shop> shopList = shopRepository.searchByKeyword(keyword);
+        List<Menu> menuList = menuRepository.searchByKeyword(keyword);
+
+        return SearchMapper.toDto(shopList, menuList);
+    }
+}

--- a/src/main/java/com/example/outsourcing/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/outsourcing/domain/search/service/SearchService.java
@@ -1,6 +1,9 @@
 package com.example.outsourcing.domain.search.service;
 
 
+import static com.example.outsourcing.domain.common.exception.base.ErrorCode.SEARCH_KEYWORD_SHORT;
+
+import com.example.outsourcing.domain.common.exception.InvalidRequestException;
 import com.example.outsourcing.domain.search.dto.SearchResponseDto;
 import com.example.outsourcing.domain.search.mapper.SearchMapper;
 import com.example.outsourcing.domain.shop.entity.Menu;
@@ -20,6 +23,9 @@ public class SearchService {
 
 
     public SearchResponseDto searchAll(String keyword) {
+        if (keyword.length() < 2) {
+            throw new InvalidRequestException(SEARCH_KEYWORD_SHORT);
+        }
         List<Shop> shopList = shopRepository.searchByKeyword(keyword);
         List<Menu> menuList = menuRepository.searchByKeyword(keyword);
 

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepository.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MenuRepository extends JpaRepository<Menu, Long> {
+public interface MenuRepository extends JpaRepository<Menu, Long>, MenuRepositoryCustom {
 
     // shopId와 삭제되지 않은 메뉴 필터링
     List<Menu> findByShopIdAndIsDeletedFalse(Long shopId);

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepositoryCustom.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.outsourcing.domain.shop.repository;
+
+import com.example.outsourcing.domain.shop.entity.Menu;
+import java.util.List;
+
+public interface MenuRepositoryCustom {
+
+    List<Menu> searchByKeyword(String keyword);
+}

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.example.outsourcing.domain.shop.repository;
+
+import com.example.outsourcing.domain.shop.entity.Menu;
+import com.example.outsourcing.domain.shop.entity.QMenu;
+import com.example.outsourcing.domain.shop.entity.QShop;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MenuRepositoryImpl implements MenuRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Menu> searchByKeyword(String keyword) {
+        QMenu qMenu = QMenu.menu;
+        QShop qShop = QShop.shop;
+
+        return queryFactory.selectFrom(qMenu)
+            .join(qMenu.shop, qShop).fetchJoin()
+            .where(qMenu.name.containsIgnoreCase(keyword)
+                .or(qMenu.description.containsIgnoreCase(keyword))
+                .and(qMenu.isDeleted.isFalse()))
+            .fetch();
+    }
+}

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/MenuRepositoryImpl.java
@@ -3,9 +3,13 @@ package com.example.outsourcing.domain.shop.repository;
 import com.example.outsourcing.domain.shop.entity.Menu;
 import com.example.outsourcing.domain.shop.entity.QMenu;
 import com.example.outsourcing.domain.shop.entity.QShop;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,6 +18,9 @@ public class MenuRepositoryImpl implements MenuRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    @Value("${spring.datasource.driver-class-name}")
+    private String driverClassName;
+
     @Override
     public List<Menu> searchByKeyword(String keyword) {
         QMenu qMenu = QMenu.menu;
@@ -21,9 +28,27 @@ public class MenuRepositoryImpl implements MenuRepositoryCustom {
 
         return queryFactory.selectFrom(qMenu)
             .join(qMenu.shop, qShop).fetchJoin()
-            .where(qMenu.name.containsIgnoreCase(keyword)
-                .or(qMenu.description.containsIgnoreCase(keyword))
-                .and(qMenu.isDeleted.isFalse()))
+            .where(qMenu.isDeleted.isFalse()
+                .and(createSearchCondition(qMenu, keyword)))
             .fetch();
+    }
+
+    private BooleanExpression createSearchCondition(QMenu qMenu, String keyword) {
+        if (isMySQL()) {
+            // MySQL 에서는 사용자 정의 함수 사용
+            NumberExpression<Double> searchCondition = Expressions.numberTemplate(Double.class,
+                "match_2params_against({0}, {1}, {2})",
+                qMenu.name, qMenu.description, keyword
+            );
+            return searchCondition.gt(0.0);
+        } else {
+            // 다른 DB 에서는 일반적인 문자열 포함 검사 사용
+            return qMenu.description.containsIgnoreCase(keyword)
+                .or(qMenu.name.containsIgnoreCase(keyword));
+        }
+    }
+
+    private boolean isMySQL() {
+        return driverClassName != null && driverClassName.contains("mysql");
     }
 }

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepository.java
@@ -5,9 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ShopRepository extends JpaRepository<Shop, Long> {
+public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositoryCustom {
 
     // 특정 사용자가 삭제되지 않은 가게를 보유하고 있는지 확인
     boolean existsByUserIdAndIsDeletedFalse(Long userId);
-    
+
 }

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepositoryCustom.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.outsourcing.domain.shop.repository;
+
+import com.example.outsourcing.domain.shop.entity.Shop;
+import java.util.List;
+
+public interface ShopRepositoryCustom {
+
+    List<Shop> searchByKeyword(String keyword);
+}

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepositoryImpl.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.example.outsourcing.domain.shop.repository;
+
+import com.example.outsourcing.domain.shop.entity.QShop;
+import com.example.outsourcing.domain.shop.entity.Shop;
+import com.example.outsourcing.domain.user.entity.QUser;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ShopRepositoryImpl implements ShopRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Shop> searchByKeyword(String keyword) {
+        QShop qShop = QShop.shop;
+        QUser qUser = QUser.user;
+
+        return queryFactory.selectFrom(qShop).join(qShop.user, qUser).fetchJoin()
+            .where(qShop.name.containsIgnoreCase(keyword)
+                .and(qShop.isDeleted.isFalse()))
+            .fetch();
+    }
+}

--- a/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepositoryImpl.java
+++ b/src/main/java/com/example/outsourcing/domain/shop/repository/ShopRepositoryImpl.java
@@ -3,9 +3,13 @@ package com.example.outsourcing.domain.shop.repository;
 import com.example.outsourcing.domain.shop.entity.QShop;
 import com.example.outsourcing.domain.shop.entity.Shop;
 import com.example.outsourcing.domain.user.entity.QUser;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,14 +18,36 @@ public class ShopRepositoryImpl implements ShopRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    @Value("${spring.datasource.driver-class-name}")
+    private String driverClassName;
+
     @Override
     public List<Shop> searchByKeyword(String keyword) {
         QShop qShop = QShop.shop;
         QUser qUser = QUser.user;
 
-        return queryFactory.selectFrom(qShop).join(qShop.user, qUser).fetchJoin()
-            .where(qShop.name.containsIgnoreCase(keyword)
-                .and(qShop.isDeleted.isFalse()))
+        return queryFactory.selectFrom(qShop)
+            .join(qShop.user, qUser).fetchJoin()
+            .where(qShop.isDeleted.isFalse()
+                .and(createSearchCondition(qShop, keyword)))
             .fetch();
+    }
+
+    private BooleanExpression createSearchCondition(QShop qShop, String keyword) {
+        if (isMySQL()) {
+            // MySQL 에서는 사용자 정의 함수 사용
+            NumberExpression<Double> searchCondition = Expressions.numberTemplate(Double.class,
+                "match_1params_against({0}, {1})",
+                qShop.name, keyword
+            );
+            return searchCondition.gt(0.0);
+        } else {
+            // 다른 DB 에서는 일반적인 문자열 포함 검사 사용
+            return qShop.name.containsIgnoreCase(keyword);
+        }
+    }
+
+    private boolean isMySQL() {
+        return driverClassName != null && driverClassName.contains("mysql");
     }
 }

--- a/src/main/java/com/example/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/com/example/outsourcing/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "users")
 @NoArgsConstructor
+@AllArgsConstructor
 public class User extends Timestamped {
 
     @Id

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.example.outsourcing.config.CustomFunctionContributor


### PR DESCRIPTION
## 완료된 기능

- [x] 메뉴와 상점 통합검색 (Fulltext 검색을 위한 MATCH AGAINST 문)

1.13s -> 0.128s 개선

<img width="958" alt="스크린샷 2025-01-09 오후 8 26 29" src="https://github.com/user-attachments/assets/a8db9ea5-bb27-46f9-94de-b58d4fbfe985" />

## 추가로

Like 기반 PR과 비교해서 적절한거 합치고 나머진 pr 닫겠습니다.

MySQL DB인지 확인해서 다른 DB면 일반 Like문으로 쿼리 보냅니다.

주의할 점은 MySQL을 사용하더라도 해당 테이블에 인덱스 생성을 미리 해두지 않으면 쿼리 날릴때 에러가 납니다.

### 풀텍스트 검색 기능 상세

MySQL의 MATCH() AGAINST() 함수를 사용하여 풀텍스트 검색 기능을 구현해야 했습니다.

그런데 이 함수는 JPA가 기본적으로 지원하지 않기 때문에, 직접 SQL 쿼리를 작성하여 이 기능을 구현할 필요가 있었습니다.

그러다 FunctionContributor 인터페이스를 구현하면 사용자 정의 함수를 Hibernate에 등록 가능하다는 걸 알았고, 이를 통해 MATCH() AGAINST() 함수를 JPA나 QueryDSL에서 마치 내장 함수처럼 사용할 수 있게 되었습니다.

- 적용 과정:
  1. 함수 등록: FunctionContributor 인터페이스를 구현하여 MATCH() AGAINST()를 포함하는 사용자 정의 함수를 등록했습니다.    
      <img width="600" alt="스크린샷 2025-01-10 오전 9 44 34" src="https://github.com/user-attachments/assets/497d02ac-9a0c-40a6-8a9c-b049f87544fe" />

  2. QueryDSL 통합: 등록된 함수를 QueryDSL 쿼리에 적용합니다.
        <img width="600" alt="스크린샷 2025-01-10 오전 9 36 31" src="https://github.com/user-attachments/assets/1a0ca326-f6fc-48aa-af45-80f96ec418a8" />


