### PR TITLE
:sparkles:feat:add white_list in jwtFilter

### DIFF
--- a/src/main/java/com/example/outsourcing/config/JwtFilter.java
+++ b/src/main/java/com/example/outsourcing/config/JwtFilter.java
@@ -18,11 +18,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.PatternMatchUtils;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtFilter implements Filter {
 
+    private static final String[] WHITE_LIST = {"/", "/auth/register", "/auth/login", "/auth/logout"};
     private final JwtUtil jwtUtil;
 
     @Override
@@ -31,7 +33,7 @@ public class JwtFilter implements Filter {
     }
 
     /*
-    JwtFilter의 역할
+    JwtFilter의 역할 -> 공부용으로 적어둔 것이오니 최종 전에 지워야 합니다.
     - 유저가 로그인 되어있는지 확인 (인증)
       */
     @Override
@@ -43,9 +45,8 @@ public class JwtFilter implements Filter {
         // 요청URL 중, 포트번호와 쿼리 사이의 부분을 가져와서 문자열형 url로 저장 (컨텍스트 경로 + 서블릿 경로)
         String url = httpRequest.getRequestURI();
 
-        // startsWith는 특정 문자열로 시작되는지 체크하는 것이므로 user변수가 /user로 시작하는 문자열이라면 chain.doFilter(request,
-        // response)를 사용하여 현재 처리 필터를 마치고 요청을 다음필터로 넘긴다. 이후 return하여 종료
-        if (url.startsWith("/auth")) {
+
+        if (isWhiteList(url)) {
             chain.doFilter(request, response);
             return;
         }
@@ -67,7 +68,7 @@ public class JwtFilter implements Filter {
             return;
         }
 
-        if (UserService.expiredTokenSet.contains(bearerJwt)) {
+        if (JwtUtil.expiredTokenSet.contains(bearerJwt)) {
             httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "토큰이 유효하지 않습니다.");
             return;
         }
@@ -130,4 +131,7 @@ public class JwtFilter implements Filter {
         chain.doFilter(httpRequest, httpResponse);
     }
 
+    private boolean isWhiteList(String requsetURI) {
+        return PatternMatchUtils.simpleMatch(WHITE_LIST, requsetURI);
+    }
 }

--- a/src/main/java/com/example/outsourcing/domain/common/util/JwtUtil.java
+++ b/src/main/java/com/example/outsourcing/domain/common/util/JwtUtil.java
@@ -9,6 +9,8 @@ import jakarta.annotation.PostConstruct;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -20,6 +22,7 @@ public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
     private static final long TOKEN_TIME = 60 * 60 * 1000L;
+    public static final Set<String> expiredTokenSet = new HashSet<>(); // 별도의 클래스에서 관리할 것
 
     @Value("${jwt.secret.key}")
     private String secretKey;

--- a/src/main/java/com/example/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/com/example/outsourcing/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import static com.example.outsourcing.domain.common.exception.base.ErrorCode.ALR
 import static com.example.outsourcing.domain.common.exception.base.ErrorCode.INVALID_TOKEN;
 import static com.example.outsourcing.domain.common.exception.base.ErrorCode.WRONG_EMAIL;
 import static com.example.outsourcing.domain.common.exception.base.ErrorCode.WRONG_PASSWORD;
+import static com.example.outsourcing.domain.common.util.JwtUtil.expiredTokenSet;
 
 import com.example.outsourcing.domain.common.exception.AuthException;
 import com.example.outsourcing.domain.common.exception.InvalidRequestException;
@@ -23,7 +24,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserService {
 
-    public static final Set<String> expiredTokenSet = new HashSet<>(); // 별도의 클래스에서 관리할 것
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
@@ -55,8 +55,9 @@ public class UserService {
         return jwtUtil.createToken(user.getId(), user.getEmail(), user.getUserRole());
     }
 
+    //jwt 필터에서는 회원가입, 로그아웃, 로그인의 필터링이 없어야 httpRequest.setAttribute로 토큰값이 저장되는 구조라서 로그아웃 여부에 대해서는 별도로 여기서 예외처리
     public void logout(String token) {
-        if (token == null) {
+        if (expiredTokenSet.contains(token)) {
             throw new AuthException(INVALID_TOKEN);
         }
         expiredTokenSet.add(token);


### PR DESCRIPTION
로그아웃에 대한 여부 예외처리 로직을 로그아웃 서비스에서 확인하게 하는 것으로 변경
기존에 jwtfilter에서 확인하는 것으로 잘못하여 에러가 났던 것으로 생각됨.
jwtFilter에는 인증에 대한 부분들 모두 화이트리스트 추가,  
로그아웃된 토큰에 대한 set의 저장 위치를 jwtutil로 이동,

+의견 )그런데 jwtFilter에 

`            httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
            httpRequest.setAttribute("email", claims.get("email"));
            String userRoleString = claims.get("userRole").toString();
            UserRole userRole = UserRole.valueOf(userRoleString);
            httpRequest.setAttribute("userRole", userRole);
`
이 부분은 토큰 인증이랑은 조금 상관없지 않나 하는 생각이 개인적으로 듭니다. 토큰을 저장하는 역할인데 try 시작하고 
` Claims claims = jwtUtil.extractClaims(jwtUtil.substringToken(bearerJwt));
          if (claims == null) {
                httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다.");
                return;
            }
`

이 부분만 체크하기 위해서 저장 자체를 필터에 넣는 게 옳은 방법일까요? 개인적인 생각으로는 이 부분은 다른 곳에서 저장하는 게 더 책임 분리에 좋지 않을까 하는 생각이 듭니다.